### PR TITLE
Bump math library versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ ultraviolet-f64 = ["ultraviolet/f64"]
 
 [dependencies]
 libm = { version = "0.2", optional = true }
-glam = { version = "0.22", optional = true }
+glam = { version = "0.24", optional = true }
 nalgebra = { version = "0.32", optional = true }
-vek = { version = "0.15", optional = true }
+vek = { version = "0.16", optional = true }
 ultraviolet = { version = "0.9.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Needed a newer version of `glam` in my own project. Bumped `vek` too since it had a newer version available.